### PR TITLE
Refresh blog styling for readability and mobile

### DIFF
--- a/_posts/2026-06-11-how-jax-allocates-memory-chinese.md
+++ b/_posts/2026-06-11-how-jax-allocates-memory-chinese.md
@@ -20,6 +20,8 @@ lang: zh
 想回答这两个问题，就得先搞明白Jax到底是怎么分配内存的——于是就有了这篇blog。
 
 
+<div class="divider"></div>
+
 ## 概览
 
 这里我们先通过一张 JAX vs. PyTorch 的对比表，来大致了解 JAX 的内存分配逻辑。我这里假设你已经熟悉 PyTorch 的 memory allocator 是如何工作的；如果还不熟悉，可以先参考这篇文章：[A guide to PyTorch's CUDA Caching Allocator](https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html)。
@@ -37,6 +39,8 @@ lang: zh
 可以看到，Jax 和 Pytorch的内存管理层级结构上基本一致，主要区别在于Jax的`BFCAllocator`和Torch的`CachingAllocator`内在的分配逻辑上有很大的不同。
 
 Jax的`BFCAllocator`走的是预分配大内存的路线，而Torch的`CachingAllocator`走的是按需申请内存然后缓存进Caching Pool的路线。
+
+<div class="divider"></div>
 
 ## 什么是BFC Allocator
 
@@ -63,6 +67,8 @@ class BFCAllocator : public Allocator {
 1. 一开始向GPU一次性要一大片连续内存（默认75%，可以通过环境变量`XLA_PYTHON_CLIENT_MEM_FRACTION`控制）。
 2. 当Jax请求内存时，从空闲的Chunk里找一块**大小最接近且够用**的（Best-Fit），如果太大就切开（Split），把大小正好的那块给用户。
 3. 当Jax释放内存时，把这块Chunk标记为空闲，并通过它的prev/next指针检查**物理**上相邻的前后Chunk是否也空闲——是的话就地合并（Coalescing），从而减少碎片化。
+
+<div class="divider"></div>
 
 ### BFC Allocator的详细数据结构
 
@@ -177,6 +183,8 @@ Bin 20: >= 256MB
 3. **Bin 是空闲块索引视角**: 
 
    Bin实际上只参与Free Chunk的索引，并且按照大小组织起来，分配时，BFC会根据从小到大的顺序从Bin里挑选一个最小单足够大的Free Chunk，这就是Best Fit的核心。
+
+<div class="divider"></div>
 
 ### BFC Allocator的API
 
@@ -400,6 +408,8 @@ BFCAllocator::ChunkHandle BFCAllocator::TryToCoalesce(ChunkHandle h, ...) {
 
 注意合并判断的依据是**物理相邻**（`prev/next`），而不是"在不在同一个Bin"。两个分属不同Bin、大小完全不同的空闲Chunk，只要地址上挨着，就能合并成一个更大的Chunk重新入Bin。
 
+
+<div class="divider"></div>
 
 ## 结论
 

--- a/_posts/2026-06-11-how-jax-allocates-memory.md
+++ b/_posts/2026-06-11-how-jax-allocates-memory.md
@@ -19,6 +19,8 @@ So when I hit the JAX OOM, two more basic questions came to mind:
 To answer them I had to first understand how JAX actually allocates memory, and that's how this post came about.
 
 
+<div class="divider"></div>
+
 ## Overview
 
 Let's start with a JAX vs. PyTorch comparison table to get a rough feel for how JAX handles memory. I'm assuming you already know how PyTorch's memory allocator works; if not, [A guide to PyTorch's CUDA Caching Allocator](https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html) is a great read.
@@ -36,6 +38,8 @@ Let's start with a JAX vs. PyTorch comparison table to get a rough feel for how 
 The layering is basically the same on both sides. The real difference is in the allocator: JAX's `BFCAllocator` vs Torch's `CachingAllocator` behave quite differently under the hood.
 
 JAX's `BFCAllocator` preallocates one big chunk of memory upfront, while Torch's `CachingAllocator` allocates on demand and caches freed blocks into a pool for reuse.
+
+<div class="divider"></div>
 
 ## What is the BFC Allocator
 
@@ -63,6 +67,8 @@ The simplified workflow is:
 1. Grab one big contiguous block of GPU memory upfront (75% by default, controlled by the `XLA_PYTHON_CLIENT_MEM_FRACTION` env var).
 2. On an allocation request, find a free chunk that's **the smallest one that still fits** (Best-Fit), and if it's too big, split it and hand back the right-sized piece.
 3. On a free, mark the chunk as free and use its prev/next pointers to check whether the **physically** adjacent chunks are also free — if so, merge them in place (Coalescing) to reduce fragmentation.
+
+<div class="divider"></div>
 
 ### The data structures inside the BFC Allocator
 
@@ -175,6 +181,8 @@ One more thing from the comment: "Allocated chunks are never in a Bin" — Bins 
 3. **Bin is the free-block index view.**
 
    Bins only index free Chunks, organized by size. On allocation, BFC scans from smaller to larger Bins to pick the smallest free Chunk that still fits — the heart of Best-Fit.
+
+<div class="divider"></div>
 
 ### The BFC Allocator's APIs
 
@@ -398,6 +406,8 @@ BFCAllocator::ChunkHandle BFCAllocator::TryToCoalesce(ChunkHandle h, ...) {
 ```
 
 Note that the merge decision is based on **physical adjacency** (`prev/next`), not "are they in the same Bin." Two free Chunks in different Bins with completely different sizes can still merge into one bigger Chunk (and get reinserted into a Bin) as long as they sit next to each other in address space.
+
+<div class="divider"></div>
 
 ## Conclusion
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,3 +1,13 @@
+// ---- Design tokens ----
+$accent: #f14e32;
+$accent-link: #c0392b;
+$text: #2b2b2b;
+$heading: #1a1a1a;
+$muted: #6a737d;
+$code-bg: #f6f8fa;
+$code-inline-bg: #eef0f2;
+$border: #e5e7eb;
+
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -7,18 +17,22 @@ html {
   margin: 0;
   padding: 0;
   height: 100%;
+  scroll-behavior: smooth;
 }
 body {
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 16px;
+  line-height: 1.7;
   font-weight: normal;
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  color: #333333;
-  padding: 20px;
+  color: $text;
+  padding: 18px;
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -webkit-text-size-adjust: 100%;
+  @media (min-width: 768px) {
+    padding: 28px 32px;
+  }
   @media (min-width: 992px) {
     padding: 35px 50px;
   }
@@ -31,26 +45,27 @@ h5,
 h6 {
     margin-bottom: 1rem;
     line-height: 1.25;
-    color: #313131;
+    color: $heading;
+    letter-spacing: -0.01em;
 }
 h1 {
-  font-size: 2rem;
+  font-size: 1.9rem;
 }
 
 h2 {
-  margin-top: 1rem;
+  margin-top: 2.2rem;
   font-size: 1.5rem;
 }
 
 h3 {
-  margin-top: 1.5rem;
+  margin-top: 1.8rem;
   font-size: 1.25rem;
 }
 
 h4,
 h5,
 h6 {
-  margin-top: 1.1rem;
+  margin-top: 1.3rem;
   font-size: 1.1rem;
 }
 img {
@@ -59,7 +74,13 @@ img {
 a {
   color: inherit;
   text-decoration: none;
-  border-bottom: 1px solid #555;
+  border-bottom: 1px solid #d0d0d0;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  &:hover,
+  &:focus {
+    color: $accent-link;
+    border-color: $accent-link;
+  }
   &.image {
     display: block;
     text-align: center;
@@ -73,10 +94,15 @@ mark {
   padding: 0 5px;
 }
 blockquote {
-  border-left: 5px solid #ccc;
-  margin: 40px 0;
-  padding: 5px 30px;
-  background: #eee;
+  border-left: 4px solid $accent;
+  margin: 1.6em 0;
+  padding: 0.6em 1.2em;
+  background: $code-bg;
+  border-radius: 0 6px 6px 0;
+  color: #4a4a4a;
+  p {
+    margin: 0.4em 0;
+  }
 }
 .logo {
   position: relative;
@@ -182,43 +208,76 @@ pre,
   font-family: Consolas, monaco, monospace;
 }
 code {
-  color: #f14e32;
-  background: #eee;
-  padding: 2px 6px;
-  font-size: 13px;
+  color: $accent;
+  background: $code-inline-bg;
+  padding: 0.15em 0.4em;
+  font-size: 0.85em;
+  border-radius: 4px;
 }
 pre {
   display: block;
   margin-top: 0;
-  margin-bottom: 1rem;
-  font-size: 0.8rem;
-  line-height: 1.4;
+  margin-bottom: 1.2rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
   white-space: pre;
   overflow-x: auto;
-  background-color: #f9f9f9;
-  border: 1px solid #ddd;
-  padding: 1rem;
+  -webkit-overflow-scrolling: touch;
+  background-color: $code-bg;
+  border: 1px solid $border;
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
   code {
     font-size: 100%;
     color: inherit;
     background-color: transparent;
     padding: 0;
+    border-radius: 0;
+  }
+  @media (max-width: 480px) {
+    font-size: 0.8rem;
+    padding: 0.85rem 0.9rem;
   }
 }
 table {
   width: 100%;
-  table-layout: fixed;
-  margin: 0px 0;
+  border-collapse: collapse;
+  margin: 1.2em 0;
+  font-size: 0.95em;
   thead {
-    background: #f2f2f2;
+    background: $code-bg;
   }
   th {
     text-align: left;
-    padding: 8px 10px;
-    border-bottom: 15px solid #fff;
+    padding: 10px 12px;
+    border-bottom: 2px solid $border;
+    font-weight: 600;
   }
   td {
-    padding: 4px 0;
+    padding: 8px 12px;
+    border-bottom: 1px solid $border;
+  }
+  tbody tr:hover {
+    background: rgba(0, 0, 0, 0.02);
+  }
+}
+
+/* Make wide markdown tables scrollable on small screens instead of squishing */
+article table:not(.feature-table) {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  th,
+  td {
+    white-space: nowrap;
+  }
+  @media (min-width: 768px) {
+    th,
+    td {
+      white-space: normal;
+    }
   }
 }
 
@@ -303,9 +362,13 @@ article {
   }
   
   h1.title {
-    line-height: 1.4em;
+    line-height: 1.3;
     text-align: center;
-    font-size: 1.4em;
+    font-size: 1.7em;
+    margin-bottom: 0.6rem;
+    @media (max-width: 480px) {
+      font-size: 1.45em;
+    }
   }
   h1, h2, h3, h4 {
     position: relative;
@@ -365,8 +428,8 @@ article {
     margin: 30px 0;
   }
   p {
-    font-size: 15px;
-    line-height: 1.9em;
+    font-size: 1.0625rem;
+    line-height: 1.8;
     word-wrap: break-word;
   }
   .footnote {
@@ -457,9 +520,8 @@ section {
       margin: 25px 0;
       .title {
         max-width: 100%;
-        //overflow: hidden !important;
-        //text-overflow: ellipsis !important;
-        //white-space: nowrap !important;
+        font-size: 1.05rem;
+        line-height: 1.5;
         word-wrap: normal !important;
       }
       a {

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,7 +1,7 @@
 /* Fix for nested list font size - match main content */
 ul li ul li, ol li ul li, ul li ol li, ol li ol li {
-  font-size: 14px !important;
-  line-height: 1.9em !important;
+  font-size: 1rem !important;
+  line-height: 1.8 !important;
 }
 
 /* Custom Table Styling */


### PR DESCRIPTION
## Summary
- Modernizes the local `the-plain` overrides (`_sass/main.scss`, `assets/custom.css`) while keeping the minimal black-on-white look:
  - Larger base type (14px → 16px) and relative line-height; bigger article paragraphs; responsive body padding.
  - Lighter link underlines with an accent-colored hover instead of the heavy `border-bottom`.
  - Rounded, GitHub-style code blocks (bigger font, better contrast, touch scrolling) and softer inline code.
  - Refined blockquotes (accent border, rounded, tighter margins).
  - **Wide markdown tables now scroll horizontally on small screens** instead of being squished by `table-layout: fixed`.
  - Smooth anchor scrolling and minor post-list polish.
- Adds section `<div class="divider"></div>` separators to the JAX memory posts (English + Chinese) to match the rest of the site.

## Notes
- No dark mode: the Rouge syntax theme in `_sass/syntax.scss` is tuned for a light background, so a dark theme is left as a possible follow-up.
- Couldn't run `bundle exec jekyll build` locally (native `google-protobuf` gem fails to compile under Ruby 4.0 in this env), but SCSS was statically validated (braces balanced, all variables defined). GitHub Pages builds in its own environment.

## Test plan
- [ ] `bundle exec jekyll serve` and check a post on desktop + a narrow mobile viewport.
- [ ] Verify the JAX vs PyTorch comparison table scrolls horizontally on mobile instead of squishing.
- [ ] Confirm code blocks, blockquotes, links, and dividers render as expected.

Made with [Cursor](https://cursor.com)