### PR TITLE
Add Zhihu link to JAX Chinese post

### DIFF
--- a/_posts/2026-06-11-how-jax-allocates-memory-chinese.md
+++ b/_posts/2026-06-11-how-jax-allocates-memory-chinese.md
@@ -19,6 +19,8 @@ lang: zh
 
 想回答这两个问题，就得先搞明白Jax到底是怎么分配内存的——于是就有了这篇blog。
 
+这篇文章也同步分享在知乎：[JAX 是怎么分配内存的](https://zhuanlan.zhihu.com/p/2049127192043446441)。
+
 
 <div class="divider"></div>
 


### PR DESCRIPTION
## Summary
- Add a Zhihu cross-post link to the Chinese JAX memory allocation post

## Verification
- PATH="/opt/homebrew/opt/ruby/bin:$PATH" bundle exec jekyll build --destination /tmp/hebiao_blog_zhihu_link_check --disable-disk-cache
- git diff --check -- _posts/2026-06-11-how-jax-allocates-memory-chinese.md