### PR TITLE
Fix mobile stylesheet cache busting

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,10 +11,15 @@
 
 <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
+{% assign asset_version = site.github.build_revision %}
+{% unless asset_version %}
+	{% assign asset_version = site.time | date: "%s" %}
+{% endunless %}
+
 <link rel="icon" href="{{ "/assets/favicon.png" | relative_url }}">
 <link rel="apple-touch-icon" href="{{ "/assets/touch-icon.png" | relative_url }}">
-<link rel="stylesheet" href="{{ "/assets/core.css" | relative_url }}">
-<link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}">
+<link rel="stylesheet" href="{{ "/assets/core.css" | relative_url }}?v={{ asset_version }}">
+<link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}?v={{ asset_version }}">
 <link rel="canonical" href="{{ page.url | prepend: site.baseurl | prepend: site.url }}">
 <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
@@ -34,4 +39,4 @@
 {% endif %}
 
 <!-- Anchor header links -->
-<script src="{{ "/assets/js/anchor-headers.js" | relative_url }}"></script>
+<script src="{{ "/assets/js/anchor-headers.js" | relative_url }}?v={{ asset_version }}"></script>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -898,24 +898,47 @@ table {
 
 @media (max-width: 560px) {
   .site-header {
-    padding: 18px 16px;
+    gap: 11px;
+    padding: 16px 16px 14px;
   }
 
   .site-brand {
     align-items: flex-start;
+    gap: 10px;
+    width: 100%;
+  }
+
+  .site-brand-mark {
+    height: 30px;
+    width: 30px;
+  }
+
+  .site-title {
+    font-size: 1.08rem;
   }
 
   .site-description {
-    font-size: 0.64rem;
+    font-size: 0.6rem;
+    max-width: 24rem;
   }
 
   .site-nav,
   .language-nav {
-    gap: 14px;
+    gap: 16px;
+    justify-content: flex-start;
+  }
+
+  .language-nav {
+    border-top: 1px solid $line-soft;
+    padding-top: 2px;
   }
 
   .home-feed {
-    padding: 24px 16px 44px;
+    padding: 20px 16px 44px;
+  }
+
+  .home-intro {
+    padding: 18px 0 26px;
   }
 
   .home-intro h1 {


### PR DESCRIPTION
## Summary
- add build-version query strings to compiled CSS and the anchor header script so mobile browsers fetch the current assets after deploys
- tighten the small-screen header and homepage intro spacing for iPhone-width layouts

## Verification
- bundle exec jekyll build
- verified at 390px viewport that CSS links include `?v=...`, header styles apply, the ML Systems title has the intended serif/border style, and there is no horizontal overflow