### PR TITLE
Hide cover art on mobile layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ lang: zh   # optional, omit for English
 
 **Homepage cover art.** Each post should have a 4:3 cover image in front matter via `image:`. The current visual direction is editorial/open-access artwork: public-domain museum images cropped into consistent 1200×900 covers. Prefer this over AI-generated abstract images unless the user explicitly asks for generated art.
 
+Mobile cover behavior is configured in `_config.yml`: `hide_cover_art_on_mobile: true` plus `mobile_cover_art_breakpoint: 719px` means cover images are not loaded or displayed on single-column phone layouts. The templates route cover images through `_includes/responsive-cover-image.html`; keep using that include instead of raw `<img>` tags for homepage/post covers.
+
 Workflow for adding a new blog cover:
 1. Find an official open-access/public-domain artwork from a stable museum source such as the Art Institute of Chicago, The Met, or the National Gallery of Art. Do not scrape Google Arts & Culture directly; use it only for inspiration, then fetch from the original museum record.
 2. Verify rights on the official source page/API. For Art Institute of Chicago API results, prefer records with `is_public_domain: true`; their API data includes CC0 metadata. For The Met API, prefer `isPublicDomain: true`.
@@ -54,7 +56,7 @@ Workflow for adding a new blog cover:
 4. Add the source to `assets/home/open-art/README.md` with filename, artwork title, artist, and official source URL.
 5. Set the post front matter `image:` to the new cover path. If the post has English and Chinese versions of the same article, reuse the same cover for both.
 6. Add or update `summary:` so homepage cards have concise editorial copy.
-7. Run `bundle exec jekyll build`, then preview the homepage and the post page. Check that the image loads, the crop works on desktop/mobile, and there is no horizontal overflow.
+7. Run `bundle exec jekyll build`, then preview the homepage and the post page. Check that the image loads and crops well on desktop, that phone-width layouts hide cover art, and that there is no horizontal overflow.
 
 Useful Art Institute IIIF image URL pattern:
 ```text

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ permalink:          /:title # Post permalink
 timezone:           America/Los_Angeles # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 mathjax:            true  # enables support for mathjax - set to 'false' to disable
 social_share_previews: true
+hide_cover_art_on_mobile: true
+mobile_cover_art_breakpoint: 719px
 
 # Site Build
 highlighter:        rouge
@@ -46,4 +48,3 @@ defaults:
       type:         "posts"
     values:
       layout:       "post"
-

--- a/_includes/responsive-cover-image.html
+++ b/_includes/responsive-cover-image.html
@@ -1,0 +1,14 @@
+{% assign image_src = include.src | default: "/assets/logo_wrapper.png" %}
+{% assign image_alt = include.alt | default: "" %}
+{% assign image_loading = include.loading | default: "lazy" %}
+{% assign mobile_breakpoint = site.mobile_cover_art_breakpoint | default: "719px" %}
+{% assign mobile_placeholder = "data:image/gif;base64,R0lGODlhAQABAAAAACw=" %}
+
+{% if site.hide_cover_art_on_mobile %}
+	<picture>
+		<source media="(max-width: {{ mobile_breakpoint }})" srcset="{{ mobile_placeholder }}">
+		<img src="{{ image_src | relative_url }}" alt="{{ image_alt | escape }}" loading="{{ image_loading }}" decoding="async">
+	</picture>
+{% else %}
+	<img src="{{ image_src | relative_url }}" alt="{{ image_alt | escape }}" loading="{{ image_loading }}" decoding="async">
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
 
 	{% if page.image %}
 		<figure class="post-cover">
-			<img src="{{ page.image | relative_url }}" alt="{{ page.title | escape }}">
+			{% include responsive-cover-image.html src=page.image alt=page.title loading="eager" %}
 		</figure>
 	{% endif %}
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -398,6 +398,14 @@ table {
   display: flex;
 }
 
+.featured-image picture,
+.post-card-image picture,
+.post-cover picture {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
 .featured-image {
   aspect-ratio: 4 / 3;
 
@@ -561,6 +569,22 @@ table {
     font-size: 0.96rem;
     line-height: 1.62;
     margin: 0;
+  }
+}
+
+@media (max-width: 719px) {
+  .featured-image,
+  .post-card-image,
+  .post-cover {
+    display: none;
+  }
+
+  .featured-post {
+    gap: 0;
+  }
+
+  .post-card-copy {
+    padding-top: 12px;
   }
 }
 

--- a/chinese.html
+++ b/chinese.html
@@ -16,11 +16,7 @@ permalink: /chinese/
 	{% if featured_post %}
 		<article class="featured-post">
 			<a class="featured-image" href="{{ featured_post.url | relative_url }}" aria-label="{{ featured_post.title | escape }}">
-				{% if featured_post.image %}
-					<img src="{{ featured_post.image | relative_url }}" alt="{{ featured_post.title | escape }}">
-				{% else %}
-					<img src="{{ "/assets/logo_wrapper.png" | relative_url }}" alt="{{ featured_post.title | escape }}">
-				{% endif %}
+				{% include responsive-cover-image.html src=featured_post.image alt=featured_post.title loading="eager" %}
 			</a>
 			<div class="featured-copy">
 				<p class="eyebrow code">最新博客</p>
@@ -55,11 +51,7 @@ permalink: /chinese/
 			{% endif %}
 			<article class="post-card">
 				<a class="post-card-image" href="{{ post.url | relative_url }}" aria-label="{{ post.title | escape }}">
-					{% if post.image %}
-						<img src="{{ post.image | relative_url }}" alt="{{ post.title | escape }}">
-					{% else %}
-						<img src="{{ "/assets/logo_wrapper.png" | relative_url }}" alt="{{ post.title | escape }}">
-					{% endif %}
+					{% include responsive-cover-image.html src=post.image alt=post.title %}
 				</a>
 				<div class="post-card-copy">
 					<time class="post-date code" datetime="{{ post.date | date_to_xmlschema }}">{{ post.updated | default: post.date | date: "%Y-%m-%d" }}</time>

--- a/index.html
+++ b/index.html
@@ -15,11 +15,7 @@ layout: default
 	{% if featured_post %}
 		<article class="featured-post">
 			<a class="featured-image" href="{{ featured_post.url | relative_url }}" aria-label="{{ featured_post.title | escape }}">
-				{% if featured_post.image %}
-					<img src="{{ featured_post.image | relative_url }}" alt="{{ featured_post.title | escape }}">
-				{% else %}
-					<img src="{{ "/assets/logo_wrapper.png" | relative_url }}" alt="{{ featured_post.title | escape }}">
-				{% endif %}
+				{% include responsive-cover-image.html src=featured_post.image alt=featured_post.title loading="eager" %}
 			</a>
 			<div class="featured-copy">
 				<p class="eyebrow code">Latest blog</p>
@@ -54,11 +50,7 @@ layout: default
 			{% endif %}
 			<article class="post-card">
 				<a class="post-card-image" href="{{ post.url | relative_url }}" aria-label="{{ post.title | escape }}">
-					{% if post.image %}
-						<img src="{{ post.image | relative_url }}" alt="{{ post.title | escape }}">
-					{% else %}
-						<img src="{{ "/assets/logo_wrapper.png" | relative_url }}" alt="{{ post.title | escape }}">
-					{% endif %}
+					{% include responsive-cover-image.html src=post.image alt=post.title %}
 				</a>
 				<div class="post-card-copy">
 					<time class="post-date code" datetime="{{ post.date | date_to_xmlschema }}">{{ post.updated | default: post.date | date: "%b %-d, %Y" }}</time>


### PR DESCRIPTION
## Summary
- add a configurable mobile cover-art switch in `_config.yml`
- route homepage/post cover images through a responsive `<picture>` include
- hide cover image containers on single-column phone layouts while keeping desktop/tablet cover art intact
- document the mobile cover behavior in `AGENTS.md`

## Verification
- `bundle exec jekyll build`
- 390px viewport: `.featured-image` and `.post-card-image` are `display: none`, the selected `currentSrc` is the transparent data URI, and there is no horizontal overflow
- 1280px viewport: cover art remains visible and selects the real artwork URL