### PR TITLE
Compact mobile homepage intro

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,8 +9,6 @@ layout: default
 		<h1 class="title">{{ page.title }}</h1>
 	</header>
 
-	<div class="divider"></div>
-
 	{{ content }}
 
 </article>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -481,6 +481,10 @@ table {
   }
 }
 
+.mobile-year-feed {
+  display: none;
+}
+
 .year-group {
   padding-top: 10px;
 
@@ -573,7 +577,10 @@ table {
 }
 
 @media (max-width: 719px) {
-  .home-intro {
+  .home-intro,
+  .featured-post,
+  .section-heading,
+  .year-group {
     display: none;
   }
 
@@ -583,12 +590,53 @@ table {
     display: none;
   }
 
-  .featured-post {
-    gap: 0;
+  .mobile-year-feed {
+    display: block;
   }
 
-  .post-card-copy {
-    padding-top: 12px;
+  .mobile-year-group {
+    margin: 0;
+  }
+
+  .mobile-year-group + .mobile-year-group {
+    border-top: 1px solid $line-soft;
+    margin-top: 22px;
+    padding-top: 18px;
+  }
+
+  .mobile-year-label {
+    color: $accent;
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    line-height: 1;
+    margin: 0 0 10px;
+    text-transform: uppercase;
+  }
+
+  .mobile-post {
+    padding: 14px 0 16px;
+  }
+
+  .mobile-post + .mobile-post {
+    border-top: 1px solid $line-soft;
+  }
+
+  .mobile-post h3 {
+    font-size: 1.34rem;
+    line-height: 1.18;
+    margin: 0.42rem 0 0.52rem;
+  }
+
+  .mobile-post a {
+    border: 0;
+  }
+
+  .mobile-post p {
+    color: $ink-soft;
+    font-size: 0.98rem;
+    line-height: 1.56;
+    margin: 0;
   }
 }
 
@@ -926,13 +974,17 @@ table {
 
 @media (max-width: 560px) {
   .site-header {
+    column-gap: 18px;
     gap: 11px;
+    grid-template-columns: auto minmax(0, 1fr);
     padding: 16px 16px 14px;
+    row-gap: 12px;
   }
 
   .site-brand {
     align-items: flex-start;
     gap: 10px;
+    grid-column: 1 / -1;
     width: 100%;
   }
 
@@ -952,13 +1004,28 @@ table {
 
   .site-nav,
   .language-nav {
-    gap: 16px;
+    flex-wrap: nowrap;
+    gap: 14px;
     justify-content: flex-start;
   }
 
+  .site-nav {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
   .language-nav {
-    border-top: 1px solid $line-soft;
-    padding-top: 2px;
+    border-top: 0;
+    grid-column: 2;
+    grid-row: 2;
+    justify-content: flex-end;
+    justify-self: end;
+    padding-top: 0;
+  }
+
+  .site-nav .nav-link,
+  .language-nav .nav-link {
+    white-space: nowrap;
   }
 
   .home-feed {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -573,6 +573,10 @@ table {
 }
 
 @media (max-width: 719px) {
+  .home-intro {
+    display: none;
+  }
+
   .featured-image,
   .post-card-image,
   .post-cover {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -615,7 +615,7 @@ table {
   }
 
   .mobile-post {
-    padding: 14px 0 16px;
+    padding: 11px 0 13px;
   }
 
   .mobile-post + .mobile-post {
@@ -630,13 +630,6 @@ table {
 
   .mobile-post a {
     border: 0;
-  }
-
-  .mobile-post p {
-    color: $ink-soft;
-    font-size: 0.98rem;
-    line-height: 1.56;
-    margin: 0;
   }
 }
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -696,6 +696,12 @@ table {
     margin: 2rem 0;
   }
 
+  .divider + h2 {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
   .center {
     text-align: left;
   }

--- a/chinese.html
+++ b/chinese.html
@@ -13,6 +13,32 @@ permalink: /chinese/
 		<p>关于 LLM 系统、训练基础设施和底层机制的技术笔记。</p>
 	</header>
 
+	<section class="mobile-year-feed" aria-label="按年份浏览文章">
+		{% assign mobile_current_year = "" %}
+			{% for post in chinese_posts %}
+				{% capture post_year %}{{ post.date | date: "%Y" }}{% endcapture %}
+				{% if post_year != mobile_current_year %}
+					{% if mobile_current_year != "" %}
+							</div>
+						</section>
+					{% endif %}
+					<section class="mobile-year-group" aria-labelledby="mobile-year-zh-{{ post_year }}">
+						<h2 id="mobile-year-zh-{{ post_year }}" class="mobile-year-label code">{{ post_year }}</h2>
+						<div class="mobile-post-list">
+					{% assign mobile_current_year = post_year %}
+				{% endif %}
+				<article class="mobile-post">
+					<time class="post-date code" datetime="{{ post.date | date_to_xmlschema }}">{{ post.updated | default: post.date | date: "%Y-%m-%d" }}</time>
+					<h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+					<p>{{ post.summary | default: post.excerpt | strip_html | strip_newlines | truncate: 110 }}</p>
+				</article>
+			{% endfor %}
+		{% if mobile_current_year != "" %}
+				</div>
+			</section>
+		{% endif %}
+	</section>
+
 	{% if featured_post %}
 		<article class="featured-post">
 			<a class="featured-image" href="{{ featured_post.url | relative_url }}" aria-label="{{ featured_post.title | escape }}">

--- a/chinese.html
+++ b/chinese.html
@@ -30,7 +30,6 @@ permalink: /chinese/
 				<article class="mobile-post">
 					<time class="post-date code" datetime="{{ post.date | date_to_xmlschema }}">{{ post.updated | default: post.date | date: "%Y-%m-%d" }}</time>
 					<h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-					<p>{{ post.summary | default: post.excerpt | strip_html | strip_newlines | truncate: 110 }}</p>
 				</article>
 			{% endfor %}
 		{% if mobile_current_year != "" %}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,32 @@ layout: default
 		<p>Notes on LLM systems, training infrastructure, and the machinery underneath.</p>
 	</header>
 
+	<section class="mobile-year-feed" aria-label="Blogs by year">
+		{% assign mobile_current_year = "" %}
+			{% for post in english_posts %}
+				{% capture post_year %}{{ post.date | date: "%Y" }}{% endcapture %}
+				{% if post_year != mobile_current_year %}
+					{% if mobile_current_year != "" %}
+							</div>
+						</section>
+					{% endif %}
+					<section class="mobile-year-group" aria-labelledby="mobile-year-{{ post_year }}">
+						<h2 id="mobile-year-{{ post_year }}" class="mobile-year-label code">{{ post_year }}</h2>
+						<div class="mobile-post-list">
+					{% assign mobile_current_year = post_year %}
+				{% endif %}
+				<article class="mobile-post">
+					<time class="post-date code" datetime="{{ post.date | date_to_xmlschema }}">{{ post.updated | default: post.date | date: "%b %-d, %Y" }}</time>
+					<h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+					<p>{{ post.summary | default: post.excerpt | strip_html | strip_newlines | truncate: 150 }}</p>
+				</article>
+			{% endfor %}
+		{% if mobile_current_year != "" %}
+				</div>
+			</section>
+		{% endif %}
+	</section>
+
 	{% if featured_post %}
 		<article class="featured-post">
 			<a class="featured-image" href="{{ featured_post.url | relative_url }}" aria-label="{{ featured_post.title | escape }}">

--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@ layout: default
 				<article class="mobile-post">
 					<time class="post-date code" datetime="{{ post.date | date_to_xmlschema }}">{{ post.updated | default: post.date | date: "%b %-d, %Y" }}</time>
 					<h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-					<p>{{ post.summary | default: post.excerpt | strip_html | strip_newlines | truncate: 150 }}</p>
 				</article>
 			{% endfor %}
 		{% if mobile_current_year != "" %}


### PR DESCRIPTION
## Summary
- hide the homepage intro/ML Systems block on phone-width layouts
- make the mobile header navigation fit on one row (`Blogs About` + `English 中文版`)
- replace the mobile homepage featured/Blogs sections with a compact year-grouped post list that includes the latest post
- make mobile post rows date + title only, with no summary copy
- reduce mobile-only divider weight by using simple year labels and soft separators between posts
- remove the redundant divider below page headers, including About
- prevent old post `<div class="divider"></div>` blocks from doubling with the new `h2` top border
- keep the desktop/tablet homepage intro and editorial layout unchanged

## Verification
- `bundle exec jekyll build`
- About output: `post-hero` is followed directly by page content, with no extra divider element
- Blog CSS output: `.divider + h2` removes the `h2` top border/padding when an old manual divider already precedes it
- 390px viewport: nav groups share one row, `.featured-post`, `.section-heading`, and desktop `.year-group` are hidden, `.mobile-year-feed` is visible, first mobile row is `Jun 11, 2026 How JAX Allocates Memory`, `.mobile-post p` count is 0, no horizontal overflow
- 1280px viewport: featured, Blogs section, and desktop year groups remain visible; mobile feed stays hidden; no horizontal overflow