### PR TITLE
Add gallery captions to post covers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,10 @@ Workflow for adding a new blog cover:
 2. Verify rights on the official source page/API. For Art Institute of Chicago API results, prefer records with `is_public_domain: true`; their API data includes CC0 metadata. For The Met API, prefer `isPublicDomain: true`.
 3. Create a cropped site asset under `assets/home/open-art/` named `<artist-or-theme>-<short-title>-cover.jpg`, resized to 1200×900, `object-fit: cover` friendly, and reasonably compressed. Do not commit huge original downloads unless specifically needed.
 4. Add the source to `assets/home/open-art/README.md` with filename, artwork title, artist, and official source URL.
-5. Set the post front matter `image:` to the new cover path. If the post has English and Chinese versions of the same article, reuse the same cover for both.
-6. Add or update `summary:` so homepage cards have concise editorial copy.
-7. Run `bundle exec jekyll build`, then preview the homepage and the post page. Check that the image loads and crops well on desktop, that phone-width layouts hide cover art, and that there is no horizontal overflow.
+5. Add the artwork metadata to `_data/open_art.yml` so post pages can render the museum-style caption with artwork title, artist, year, and source link.
+6. Set the post front matter `image:` to the new cover path. If the post has English and Chinese versions of the same article, reuse the same cover for both.
+7. Add or update `summary:` so homepage cards have concise editorial copy.
+8. Run `bundle exec jekyll build`, then preview the homepage and the post page. Check that the image loads and crops well on desktop, that the post page caption appears, that phone-width layouts hide cover art, and that there is no horizontal overflow.
 
 Useful Art Institute IIIF image URL pattern:
 ```text

--- a/_data/open_art.yml
+++ b/_data/open_art.yml
@@ -1,0 +1,45 @@
+- src: /assets/home/open-art/seurat-la-grande-jatte-cover.jpg
+  title: A Sunday on La Grande Jatte - 1884
+  artist: Georges Seurat
+  year: 1884-86, border added 1888-89
+  source: https://www.artic.edu/artworks/27992/a-sunday-on-la-grande-jatte-1884
+- src: /assets/home/open-art/monet-water-lilies-cover.jpg
+  title: Water Lilies
+  artist: Claude Monet
+  year: "1906"
+  source: https://www.artic.edu/artworks/16568/water-lilies
+- src: /assets/home/open-art/monet-normandy-train-cover.jpg
+  title: Arrival of the Normandy Train, Gare Saint-Lazare
+  artist: Claude Monet
+  year: "1877"
+  source: https://www.artic.edu/artworks/16571/arrival-of-the-normandy-train-gare-saint-lazare
+- src: /assets/home/open-art/monet-stacks-of-wheat-cover.jpg
+  title: Stacks of Wheat (End of Summer)
+  artist: Claude Monet
+  year: 1890-91
+  source: https://www.artic.edu/artworks/64818/stacks-of-wheat-end-of-summer
+- src: /assets/home/open-art/vangogh-bedroom-cover.jpg
+  title: The Bedroom
+  artist: Vincent van Gogh
+  year: "1889"
+  source: https://www.artic.edu/artworks/28560/the-bedroom
+- src: /assets/home/open-art/vangogh-poets-garden-cover.jpg
+  title: The Poet's Garden
+  artist: Vincent van Gogh
+  year: "1888"
+  source: https://www.artic.edu/artworks/14586/the-poet-s-garden
+- src: /assets/home/open-art/caillebotte-paris-street-rainy-day-cover.jpg
+  title: Paris Street; Rainy Day
+  artist: Gustave Caillebotte
+  year: "1877"
+  source: https://www.artic.edu/artworks/20684/paris-street-rainy-day
+- src: /assets/home/open-art/cezanne-basket-of-apples-cover.jpg
+  title: The Basket of Apples
+  artist: Paul Cezanne
+  year: c. 1893
+  source: https://www.artic.edu/artworks/111436/the-basket-of-apples
+- src: /assets/home/open-art/cezanne-bay-of-marseille-cover.jpg
+  title: The Bay of Marseille, Seen from L'Estaque
+  artist: Paul Cezanne
+  year: c. 1885
+  source: https://www.artic.edu/artworks/16487/the-bay-of-marseille-seen-from-l-estaque

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,8 +14,20 @@ layout: default
 	</header>
 
 	{% if page.image %}
+		{% assign artwork = site.data.open_art | where: "src", page.image | first %}
+		{% assign cover_alt = page.title %}
+		{% if artwork %}
+			{% assign cover_alt = artwork.title %}
+		{% endif %}
 		<figure class="post-cover">
-			{% include responsive-cover-image.html src=page.image alt=page.title loading="eager" %}
+			{% include responsive-cover-image.html src=page.image alt=cover_alt loading="eager" %}
+			{% if artwork %}
+				<figcaption class="artwork-caption">
+					<span class="artwork-caption-title">{{ artwork.title }}</span>
+					<span class="artwork-caption-meta">{{ artwork.artist }}, {{ artwork.year }}</span>
+					<a class="artwork-caption-source" href="{{ artwork.source }}">Art Institute of Chicago</a>
+				</figcaption>
+			{% endif %}
 		</figure>
 	{% endif %}
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -676,18 +676,60 @@ table {
   }
 
   .post-cover {
-    aspect-ratio: 16 / 9;
-    display: flex;
-    margin: 0 0 2rem;
+    background: transparent;
+    border: 0;
+    display: block;
+    margin: 0 0 2.4rem;
+    overflow: visible;
+
+    picture {
+      aspect-ratio: 4 / 3;
+      background: $wash;
+      display: flex;
+      height: auto;
+      overflow: hidden;
+      width: 100%;
+    }
 
     img {
       border: 0;
       height: 100%;
       margin: 0;
-      object-fit: contain;
-      padding: 22px;
+      object-fit: cover;
+      padding: 0;
       width: 100%;
     }
+  }
+
+  .artwork-caption {
+    color: $muted;
+    display: grid;
+    gap: 0.24rem;
+    margin-top: 0.68rem;
+  }
+
+  .artwork-caption-title {
+    color: $ink;
+    font-family: $serif;
+    font-size: 0.98rem;
+    font-style: italic;
+    line-height: 1.28;
+  }
+
+  .artwork-caption-meta,
+  .artwork-caption-source {
+    font-family: $mono;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    line-height: 1.35;
+    text-transform: uppercase;
+  }
+
+  .artwork-caption-source {
+    border-bottom: 1px solid currentColor;
+    color: $accent-cool;
+    justify-self: start;
   }
 
   .divider {
@@ -1041,10 +1083,6 @@ table {
 
   .featured-copy h2 {
     font-size: 1.8rem;
-  }
-
-  .post-cover img {
-    padding: 16px;
   }
 
   .site-main > article {


### PR DESCRIPTION
## Summary
- add open artwork metadata for the post cover images
- render museum-style artwork captions under post cover art
- remove the hard framed/padded look from post cover images
- keep homepage/list cover art hidden on phone-width pages while still showing post cover art inside blog posts
- use a valid transparent mobile placeholder only where cover art is intentionally suppressed
- update blog cover workflow notes for future posts

## Verification
- bundle exec jekyll build
- git diff --check
- metadata coverage check for all _posts open-art cover images
- inspected generated post HTML: post cover uses the real artwork image and has no mobile placeholder source
- inspected generated homepage HTML/CSS: homepage/list cover images remain suppressed on phone-width layouts