### PR TITLE
Show post cover art on mobile

### DIFF
--- a/_includes/responsive-cover-image.html
+++ b/_includes/responsive-cover-image.html
@@ -2,13 +2,19 @@
 {% assign image_alt = include.alt | default: "" %}
 {% assign image_loading = include.loading | default: "lazy" %}
 {% assign mobile_breakpoint = site.mobile_cover_art_breakpoint | default: "719px" %}
-{% assign mobile_placeholder = "data:image/gif;base64,R0lGODlhAQABAAAAACw=" %}
+{% assign mobile_placeholder = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" %}
+{% assign hide_on_mobile = site.hide_cover_art_on_mobile %}
+{% unless include.hide_on_mobile == nil %}
+	{% assign hide_on_mobile = include.hide_on_mobile %}
+{% endunless %}
 
-{% if site.hide_cover_art_on_mobile %}
+{% if hide_on_mobile %}
 	<picture>
 		<source media="(max-width: {{ mobile_breakpoint }})" srcset="{{ mobile_placeholder }}">
 		<img src="{{ image_src | relative_url }}" alt="{{ image_alt | escape }}" loading="{{ image_loading }}" decoding="async">
 	</picture>
 {% else %}
-	<img src="{{ image_src | relative_url }}" alt="{{ image_alt | escape }}" loading="{{ image_loading }}" decoding="async">
+	<picture>
+		<img src="{{ image_src | relative_url }}" alt="{{ image_alt | escape }}" loading="{{ image_loading }}" decoding="async">
+	</picture>
 {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,7 @@ layout: default
 			{% assign cover_alt = artwork.title %}
 		{% endif %}
 		<figure class="post-cover">
-			{% include responsive-cover-image.html src=page.image alt=cover_alt loading="eager" %}
+			{% include responsive-cover-image.html src=page.image alt=cover_alt loading="eager" hide_on_mobile=false %}
 			{% if artwork %}
 				<figcaption class="artwork-caption">
 					<span class="artwork-caption-title">{{ artwork.title }}</span>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -585,8 +585,7 @@ table {
   }
 
   .featured-image,
-  .post-card-image,
-  .post-cover {
+  .post-card-image {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- allow the responsive cover image include to opt out of mobile suppression per call
- keep blog post cover art visible on phone-width post pages
- continue suppressing homepage/list cover art on phone-width layouts with a valid transparent placeholder

## Verification
- bundle exec jekyll build
- git diff --cached --check
- metadata coverage check for all _posts open-art cover images
- generated HTML/CSS assertions:
  - post pages render the real cover image without a mobile placeholder source
  - homepage/list cover images keep the mobile placeholder
  - mobile CSS hides homepage/list images but not .post-cover