### PR TITLE
Fix author social icon styling

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -865,12 +865,13 @@ table {
 
 .authors-section {
   flex-wrap: wrap;
+}
 
-  img {
-    background: transparent;
-    border: 0;
-    margin: 0;
-  }
+.site-main > article .authors-section img {
+  background: transparent;
+  border: 0;
+  display: inline-block;
+  margin: 0;
 }
 
 .site-main > article table:not(.feature-table) {


### PR DESCRIPTION
## Summary
- raise the author-section image override specificity so social icons are not styled as article content images
- remove the unintended background, border, block layout, and large margins from author social icons

## Verification
- bundle exec jekyll build
- git diff --check
- generated CSS assertions confirmed:
  - article images still keep their normal framed styling
  - .site-main > article .authors-section img overrides background/border/display/margin for social icons
- local /rl-weight-sync returned 200